### PR TITLE
Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Last confirmed working version of iTunes: `12.2.1`.
 
 ## Setup
 
-    npm install
-    npm run start
+    script/bootstrap
+    script/server
 
 iTunes API will run on port `8181` by default. Use the `PORT` environment
 variable to use your own port.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Last confirmed working version of iTunes: `12.2.1`.
 iTunes API will run on port `8181` by default. Use the `PORT` environment
 variable to use your own port.
 
+## Logging
+
+iTunes API logs all of its requests. In `production`, it logs to a file at `log/production.log`.
+In development mode, it just logs to stdout.
+
+## Development
+
+Launch the app via `npm run start` to run it in the development environment.
+
 ## Docs
 
 This is a quick overview of the service. Read [app.js](app.js) if you need more

--- a/app.js
+++ b/app.js
@@ -2,14 +2,27 @@ var fs = require('fs')
 var path = require('path')
 var util = require('util')
 var express = require('express')
+var morgan = require('morgan')
 var bodyParser = require('body-parser')
 var iTunes = require('local-itunes')
 var osa = require('osa')
 var osascript = require(path.join(__dirname, 'node_modules', 'local-itunes', 'node_modules', 'osascript'))
 var airplay = require('./lib/airplay')
 
+var env = process.env.NODE_ENV || 'development';
+var logDirectory = __dirname + '/log'
+
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))
+
+var logFormat = "'[:date[iso]] - :remote-addr - :method :url :status :response-time ms - :res[content-length]b'"
+if ('development' == env){
+  app.use(morgan(logFormat))
+}else if ('production' == env){
+  fs.existsSync(logDirectory) || fs.mkdirSync(logDirectory)
+  var accessLogStream = fs.createWriteStream(logDirectory + '/' + env + '.log', {flags: 'a'})
+  app.use(morgan(logFormat, {stream: accessLogStream}))
+}
 
 function getCurrentState(){
   itunes = Application('iTunes');

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "express": "^4.12.4",
+    "morgan": "^1.6.1",
     "body-parser": "^1.12.4",
     "local-itunes": "^0.3.0",
     "osa": "2.2.0"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm install

--- a/script/server
+++ b/script/server
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+test -z "$NODE_ENV" &&
+  export NODE_ENV='production'
+
+npm run start


### PR DESCRIPTION
This adds logging. Every http request will be logged out now.

In production it logs out to `log/production.log` and in dev it logs to stdout.

logs look like this:

>'[2015-08-13T18:51:45.769Z] - ::ffff:127.0.0.1 - GET /airplay_devices 200 103.442 ms - 979b'

`datetime` - `request ip` - `http method` `path` `response status code` `request time` - `size of response`

