### PR TITLE
Forever

### DIFF
--- a/.foreverignore
+++ b/.foreverignore
@@ -1,0 +1,7 @@
+config/*
+log/*
+script/*
+.gitignore
+LICENCE
+package.json
+README.md

--- a/README.md
+++ b/README.md
@@ -23,19 +23,34 @@ Last confirmed working version of iTunes: `12.2.1`.
 ## Setup
 
     script/bootstrap
-    script/server
 
-iTunes API will run on port `8181` by default. Use the `PORT` environment
+## Running It
+Get up and running immediatly with `script/server`.
+
+iTunes API will run on port `8282` by default. Use the `PORT` environment
 variable to use your own port.
+
+### Forever
+iTunes API has support for [Forever](https://github.com/foreverjs/forever). It uses
+`launchd` on OS X to kick it off so that it starts on boot. There is no `init.d`
+other Linux support of this type. Pull requests would be welcome for this though.
+
+### Development
+You can simply run it by calling `script/server`. This will run it in development
+mode with logging to standard out.
+
+### Install as Service on OS X
+
+    script/install
 
 ## Logging
 
-iTunes API logs all of its requests. In `production`, it logs to a file at `log/production.log`.
-In development mode, it just logs to stdout.
+iTunes API logs all of its requests. In `production`, it logs to a file at `log/logs.log`.
+In `development` mode, it just logs to stdout.
 
 ## Development
 
-Launch the app via `npm run start` to run it in the development environment.
+Launch the app via `script/server` to run it in the development environment.
 
 ## Docs
 

--- a/app.js
+++ b/app.js
@@ -9,20 +9,11 @@ var osa = require('osa')
 var osascript = require(path.join(__dirname, 'node_modules', 'local-itunes', 'node_modules', 'osascript'))
 var airplay = require('./lib/airplay')
 
-var env = process.env.NODE_ENV || 'development';
-var logDirectory = __dirname + '/log'
-
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))
 
 var logFormat = "'[:date[iso]] - :remote-addr - :method :url :status :response-time ms - :res[content-length]b'"
-if ('development' == env){
-  app.use(morgan(logFormat))
-}else if ('production' == env){
-  fs.existsSync(logDirectory) || fs.mkdirSync(logDirectory)
-  var accessLogStream = fs.createWriteStream(logDirectory + '/' + env + '.log', {flags: 'a'})
-  app.use(morgan(logFormat, {stream: accessLogStream}))
-}
+app.use(morgan(logFormat))
 
 function getCurrentState(){
   itunes = Application('iTunes');

--- a/config/forever/development.json
+++ b/config/forever/development.json
@@ -1,0 +1,5 @@
+{
+  "append": true,
+  "watch": true,
+  "script": "app.js"
+}

--- a/config/forever/production.json
+++ b/config/forever/production.json
@@ -1,0 +1,7 @@
+{
+  "uid": "itunes-api",
+  "append": true,
+  "script": "app.js",
+  "outFile": "log/logs.log",
+  "errFile": "log/error.log"
+}

--- a/config/org.itunes-api.plist
+++ b/config/org.itunes-api.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>org.itunes-api</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/usr/local/bin/:$PATH</string>
+      <key>NODE_ENV</key>
+      <string>production</string>
+    </dict>
+
+    <key>Program</key>
+    <string>script/server</string>
+
+    <key>AbandonProcessGroup</key>
+    <false/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>%PATH%</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/%USER%/Library/Logs/itunes-api.log</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/%USER%/Library/Logs/itunes-api.log</string>
+
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itunes-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "itunes-api",
   "scripts": {
     "start": "node app.js"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,3 +1,19 @@
 #!/bin/sh
 
+set -e
+
+if ! test $(which forever)
+then
+  echo
+  echo "!!!!"
+  echo "You don't have forever installed. You need to install it first."
+  echo
+  echo "Just install it with this command: "
+  echo 'sudo npm install forever -g'
+  echo
+  exit 1
+fi
+
 npm install
+
+echo "Finished setting up itunes-api! run it with script/server or install it with script/install."

--- a/script/install
+++ b/script/install
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+echo "Installing itunes-api..."
+
+APP_PATH=`pwd`
+USER_NAME=`whoami`
+
+cp config/org.itunes-api.plist ~/Library/LaunchAgents/org.itunes-api.plist
+
+sed -i '' -e "s#%USER%#$USER_NAME#g" ~/Library/LaunchAgents/org.itunes-api.plist
+sed -i '' -e "s#%PATH%#$APP_PATH#g" ~/Library/LaunchAgents/org.itunes-api.plist
+
+launchctl load -w -F ~/Library/LaunchAgents/org.itunes-api.plist

--- a/script/restart
+++ b/script/restart
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+script/uninstall
+script/install

--- a/script/server
+++ b/script/server
@@ -1,6 +1,10 @@
 #!/bin/sh
 
 test -z "$NODE_ENV" &&
-  export NODE_ENV='production'
+  export NODE_ENV='development'
 
-npm run start
+if [ "$NODE_ENV" = "development" ]; then
+  /usr/local/bin/forever -f config/forever/development.json
+else
+  /usr/local/bin/forever start config/forever/production.json
+fi

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "Uninstalling itunes-api..."
+forever stop itunes-api > /dev/null 2>&1
+launchctl unload ~/Library/LaunchAgents/org.itunes-api.plist
+rm ~/Library/LaunchAgents/org.itunes-api.plist

--- a/script/upgrade
+++ b/script/upgrade
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo "Updating from GitHub..."
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git pull origin $BRANCH
+
+npm update
+
+script/restart

--- a/templates/org.itunes-api.plist
+++ b/templates/org.itunes-api.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>org.itunes-api</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/usr/local/bin/:$PATH</string>
+      <key>NODE_ENV</key>
+      <string>production</string>
+    </dict>
+
+    <key>Program</key>
+    <string>script/server</string>
+
+    <key>AbandonProcessGroup</key>
+    <false/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/jmaddox/source/itunes</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/jmaddox/Library/Logs/itunes-api.log</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/jmaddox/Library/Logs/itunes-api.log</string>
+
+  </dict>
+</plist>


### PR DESCRIPTION
This adds support for Forever. This keeps the app launched.

All logging goes to standard out now and logs are written by Forever.

This also adds a way to install the app as a service on OS X via `launchd`.

Just run `script/install` and you'll be off to the races.