### PR TITLE
Airplay Volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ AirPlay device on your network.
   "kind": "Apple TV",
   "active": true,
   "selected": true,
-  "soundVolume": 60,
-  "supportsVideo": true,
-  "supportsAudio": true,
-  "networkAddress": "63:22:fa:1f:f5:d4"
+  "volume": 60,
+  "supports_video": true,
+  "supports_audio": true,
+  "network_address": "63:22:fa:1f:f5:d4"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ These are the endpoints you can hit to do things.
     GET /airplay_devices => {"airplay_devices": [AirPlayDevice, AirPlayDevice, ...]}
     PUT /airplay_devices/:id/on => AirPlayDevice
     PUT /airplay_devices/:id/off => AirPlayDevice
+    PUT /volume [level=20] => AirPlayDevice
 
 ## Contributions
 

--- a/app.js
+++ b/app.js
@@ -271,5 +271,15 @@ app.put('/airplay_devices/:id/off', function (req, res) {
   })
 })
 
+app.put('/airplay_devices/:id/volume', function (req, res) {
+  osa(airplay.setVolumeAirPlayDevice, req.params.id, req.body.level, function(error, data, log){
+    if (error){
+      console.log(error)
+      res.sendStatus(500)
+    }else{
+      res.json(data)
+    }
+  })
+})
 
 app.listen(process.env.PORT || 8181);

--- a/lib/airplay.js
+++ b/lib/airplay.js
@@ -15,10 +15,10 @@ module.exports = {
       deviceData["kind"] = airPlayDevice.kind();
       deviceData["active"] = airPlayDevice.active();
       deviceData["selected"] = airPlayDevice.selected();
-      deviceData["soundVolume"] = airPlayDevice.soundVolume();
-      deviceData["supportsVideo"] = airPlayDevice.supportsVideo();
-      deviceData["supportsAudio"] = airPlayDevice.supportsAudio();
-      deviceData["networkAddress"] = airPlayDevice.networkAddress();
+      deviceData["sound_volume"] = airPlayDevice.soundVolume();
+      deviceData["supports_video"] = airPlayDevice.supportsVideo();
+      deviceData["supports_audio"] = airPlayDevice.supportsAudio();
+      deviceData["network_address"] = airPlayDevice.networkAddress();
 
       airPlayResults.push(deviceData);
     }
@@ -49,10 +49,10 @@ module.exports = {
       deviceData["kind"] = foundAirPlayDevice.kind();
       deviceData["active"] = foundAirPlayDevice.active();
       deviceData["selected"] = foundAirPlayDevice.selected();
-      deviceData["soundVolume"] = foundAirPlayDevice.soundVolume();
-      deviceData["supportsVideo"] = foundAirPlayDevice.supportsVideo();
-      deviceData["supportsAudio"] = foundAirPlayDevice.supportsAudio();
-      deviceData["networkAddress"] = foundAirPlayDevice.networkAddress();
+      deviceData["sound_volume"] = foundAirPlayDevice.soundVolume();
+      deviceData["supports_video"] = foundAirPlayDevice.supportsVideo();
+      deviceData["supports_audio"] = foundAirPlayDevice.supportsAudio();
+      deviceData["network_address"] = foundAirPlayDevice.networkAddress();
     }
 
     return deviceData;

--- a/lib/airplay.js
+++ b/lib/airplay.js
@@ -56,5 +56,36 @@ module.exports = {
     }
 
     return deviceData;
+  },
+  setVolumeAirPlayDevice: function (id, level){
+    itunes = Application('iTunes');
+    id = id.replace(/-/g, ':');
+    foundAirPlayDevice = null;
+    deviceData = {};
+
+    airPlayDevices = itunes.airplayDevices();
+    for (i = 0; i < airPlayDevices.length; i++) {
+      airPlayDevice = airPlayDevices[i];
+
+      if (airPlayDevice.networkAddress() == id){
+        foundAirPlayDevice = airPlayDevice;
+        break;
+      }
+    }
+
+    if (foundAirPlayDevice) {
+      foundAirPlayDevice.soundVolume = level;
+
+      deviceData["id"] = foundAirPlayDevice.networkAddress().replace(/:/g, '-');
+      deviceData["name"] = foundAirPlayDevice.name();
+      deviceData["kind"] = foundAirPlayDevice.kind();
+      deviceData["active"] = foundAirPlayDevice.active();
+      deviceData["selected"] = foundAirPlayDevice.selected();
+      deviceData["sound_volume"] = foundAirPlayDevice.soundVolume();
+      deviceData["supports_audio"] = foundAirPlayDevice.supportsAudio();
+      deviceData["network_address"] = foundAirPlayDevice.networkAddress();
+    }
+
+    return deviceData;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,7 @@
         <p><span class="method">GET</span> <a href="/airplay_devices">/airplay_devices</a></p>
         <p><span class="method">PUT</span> /airplay_devices/:id/on</p>
         <p><span class="method">PUT</span> /airplay_devices/:id/off</p>
+        <p><span class="method">PUT</span> /airplay_devices/:id/volume [level=20]</p>
       </div>
 
       <div class="footer">


### PR DESCRIPTION
Adds a new endpoint to set the volume of an airplay device:

        PUT /airplay_device/:id/volume [level=20] => AirplayDeviceResource

The PUT takes a number from 0 to 100 param named `level`.

This pull also normalizes the keys across the response JSON to always be underscored.
 