### PR TITLE
Add missing dependency "osascript"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.12.4",
     "local-itunes": "^0.3.0",
     "osa": "2.2.0",
+    "osascript": "1.2.0",
     "parameterize": "^0.0.7"
   }
 }


### PR DESCRIPTION
Hej, I had the same problem like described in #15 
```
Error: Cannot find module '/Users/.../itunes-api/node_modules/local-itunes/node_modules/osascript'
````

I fixed it by installing osascript manually but I guess it should just be part of the dependencies. Am I wrong?