### PR TITLE
Expose 'Computer' as an airplay endpoint

### DIFF
--- a/lib/airplay.js
+++ b/lib/airplay.js
@@ -7,10 +7,12 @@ module.exports = {
     for (i = 0; i < airPlayDevices.length; i++) {
       airPlayDevice = airPlayDevices[i];
 
-      if (!airPlayDevice.networkAddress()) continue;
-
       deviceData = {};
-      deviceData["id"] = airPlayDevice.networkAddress().replace(/:/g, '-');
+      if (airPlayDevice.networkAddress()) {
+        deviceData["id"] = airPlayDevice.networkAddress().replace(/:/g, '-');
+      } else {
+        deviceData["id"] = airPlayDevice.name();
+      }
       deviceData["name"] = airPlayDevice.name();
       deviceData["kind"] = airPlayDevice.kind();
       deviceData["active"] = airPlayDevice.active();
@@ -35,7 +37,7 @@ module.exports = {
     for (i = 0; i < airPlayDevices.length; i++) {
       airPlayDevice = airPlayDevices[i];
 
-      if (airPlayDevice.networkAddress() == id){
+      if (airPlayDevice.networkAddress() == id || airPlayDevice.name() == id) {
         foundAirPlayDevice = airPlayDevice;
         break;
       }
@@ -44,7 +46,11 @@ module.exports = {
     if (foundAirPlayDevice) {
       foundAirPlayDevice.selected = selected;
 
-      deviceData["id"] = foundAirPlayDevice.networkAddress().replace(/:/g, '-');
+      if (foundAirPlayDevice.networkAddress()) {
+        deviceData["id"] = foundAirPlayDevice.networkAddress().replace(/:/g, '-');
+      } else {
+        deviceData["id"] = foundAirPlayDevice.name();
+      }
       deviceData["name"] = foundAirPlayDevice.name();
       deviceData["kind"] = foundAirPlayDevice.kind();
       deviceData["active"] = foundAirPlayDevice.active();
@@ -67,7 +73,7 @@ module.exports = {
     for (i = 0; i < airPlayDevices.length; i++) {
       airPlayDevice = airPlayDevices[i];
 
-      if (airPlayDevice.networkAddress() == id){
+      if (airPlayDevice.networkAddress() == id || airPlayDevice.name() == id) {
         foundAirPlayDevice = airPlayDevice;
         break;
       }
@@ -76,7 +82,11 @@ module.exports = {
     if (foundAirPlayDevice) {
       foundAirPlayDevice.soundVolume = level;
 
-      deviceData["id"] = foundAirPlayDevice.networkAddress().replace(/:/g, '-');
+      if (foundAirPlayDevice.networkAddress()) {
+        deviceData["id"] = foundAirPlayDevice.networkAddress().replace(/:/g, '-');
+      } else {
+        deviceData["id"] = foundAirPlayDevice.name();
+      }
       deviceData["name"] = foundAirPlayDevice.name();
       deviceData["kind"] = foundAirPlayDevice.kind();
       deviceData["active"] = foundAirPlayDevice.active();


### PR DESCRIPTION
The iTunes instance I'd like to control has speakers and is in the same room as another Airplay endpoint. This change allows me to turn on Airplay devices while turning off computer's speakers to avoid the echo that results when they're both on at the same time.

The way I've implemented this expects that all of the Airplay devices without a network address have a unique name. I've never seen such a device with any name other than Computer, so I think that assumption holds.

Do I need to sign a CLA or anything or will ca113d3f17b8330c033cfdac1474fae07ea2e3c6 suffice? :trollface: 