### PR TITLE
Fuzzy match playlist names if no direct hit

### DIFF
--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -1,0 +1,26 @@
+var dice = require('clj-fuzzy').metrics.dice
+var console = require('console')
+
+exports.confidentMatch = function confidentMatch(words, matchWord) {
+  scoreSort = function(x, y){ return y[1] - x[1]}
+
+  var results = words.map(function(word){
+   score = dice(word, matchWord)
+   return [word, score]
+  })
+
+  results = results.sort(scoreSort)
+  results.length = 2
+
+  var firstMatchConfidence = results[0][1]
+  var secondMatchConfidence = results[1][1]
+  var confidenceDelta = firstMatchConfidence - secondMatchConfidence
+
+  console.log(results)
+
+  if (firstMatchConfidence >= 0.4 && confidenceDelta >= 0.1) {
+    return results[0][0]
+  } else {
+    return false
+  }
+}

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -16,7 +16,7 @@ exports.confidentMatch = function confidentMatch(words, matchWord) {
 
   console.log(results)
 
-  if (firstMatchConfidence >= 0.4) {
+  if (firstMatchConfidence >= 0.3) {
     return results[0][0]
   } else {
     return false

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -13,12 +13,10 @@ exports.confidentMatch = function confidentMatch(words, matchWord) {
   results.length = 2
 
   var firstMatchConfidence = results[0][1]
-  var secondMatchConfidence = results[1][1]
-  var confidenceDelta = firstMatchConfidence - secondMatchConfidence
 
   console.log(results)
 
-  if (firstMatchConfidence >= 0.4 && confidenceDelta >= 0.1) {
+  if (firstMatchConfidence >= 0.4) {
     return results[0][0]
   } else {
     return false

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "local-itunes": "^0.3.0",
     "osa": "2.2.0",
     "osascript": "1.2.0",
-    "parameterize": "^0.0.7"
+    "parameterize": "^0.0.7",
+    "clj-fuzzy": "^0.3.1"
   }
 }


### PR DESCRIPTION
A first attempt that seems to be working. Fuzzy matching only kicks in if there are no direct hits on a playlist id. The Sorensen / Dice coefficient is calculated for the provided name against each playlists in the library using https://github.com/Yomguithereal/clj-fuzzy, and the top two results returned. A playlist is played if:

* The top coefficient is >= 0.4
* The difference between the top two coefficient values is at least 0.1

I'd like to run this for a bit before merging to get some real world experience with that selection strategy, but I figured I'd open the PR sooner rather to get feedback on the approach.